### PR TITLE
[Issue-0000] Upgrade to Gradle 7

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,25 +3,20 @@
 <!-- Add issue link -->
 Issue: https://github.com/touchlab/KaMPKit/issues/[issue number]
 
-## [Platform]
-<!-- Select / Unselect the appropriate platforms -->
-- [x] iOS
-- [ ] Android
-- [x] KMP
-
-## [Summary]
+## Summary
 <!--- Copy summary from issue link or write a shortened description of it -->
 
-## [Fix]
+## Fix
 <!-- What did you do to fix the issue? -->
 
-## [Testing]
-- <!-- (if applicable) unit tests -->
-- <!-- (if applicable) integration tests -->
-- <!-- (if applicable) UI tests -->
-- <!-- (if applicable) manual tests -->
-- <!-- (if applicable) screenshots -->
+## Testing
+<!-- Remove any lines that were not performed -->
+- `./gradlew :app:build`
+- `./gradlew :shared:build`
+- `xcodebuild -workspace ios/KaMPKitiOS.xcworkspace -scheme KaMPKitiOS 
+    -sdk iphoneos -configuration Debug build -destination name="iPhone 8"`
+- manual testing
 
-###### Reviewer Tips:
-###### * Use "Nitpick:" if it's a minor non-crucial request.
-###### * If you're done with comments either end with a review or comment something helpful like "done with comments for now"
+<!-- If you made changes to the UI, please show us what it looks like now. -->
+### **Screenshot / Video of App working with the Changes**
+<img width="250" alt="fix in action" src="https://media.makeameme.org/created/yes-it-works.jpg">

--- a/.github/workflows/KaMPKit-Android.yml
+++ b/.github/workflows/KaMPKit-Android.yml
@@ -19,6 +19,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: actions/setup-java@v2
+        with:
+          distribution: "adopt"
+          java-version: "11"
+
       - name: Build
         run: ./gradlew :app:build
 

--- a/.github/workflows/KaMPKit-Shared.yml
+++ b/.github/workflows/KaMPKit-Shared.yml
@@ -20,6 +20,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: actions/setup-java@v2
+        with:
+          distribution: "adopt"
+          java-version: "11"
+
       - name: Build
         run: ./gradlew :shared:build
 

--- a/.github/workflows/KaMPKit-iOS.yml
+++ b/.github/workflows/KaMPKit-iOS.yml
@@ -19,6 +19,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: actions/setup-java@v2
+        with:
+          distribution: "adopt"
+          java-version: "11"
+
       - name: Build
         uses: sersoft-gmbh/xcodebuild-action@v1
         with:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,18 +4,18 @@ plugins {
 }
 
 android {
-    compileSdkVersion(Versions.compile_sdk)
+    compileSdk = Versions.compile_sdk
     buildToolsVersion = Versions.buildToolsVersion
     defaultConfig {
         applicationId = "co.touchlab.kampkit"
-        minSdkVersion(Versions.min_sdk)
-        targetSdkVersion(Versions.target_sdk)
+        minSdk = Versions.min_sdk
+        targetSdk = Versions.target_sdk
         versionCode = 1
         versionName = "1.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
     packagingOptions {
-        exclude("META-INF/*.kotlin_module")
+        resources.excludes.add("META-INF/*.kotlin_module")
     }
     buildTypes {
         getByName("release") {
@@ -29,7 +29,7 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    lintOptions {
+    lint {
         isWarningsAsErrors = true
         isAbortOnError = true
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,9 +10,10 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        android:name="co.touchlab.kampkit.android.MainApp"
-    >
-        <activity android:name="co.touchlab.kampkit.android.MainActivity">
+        android:name="co.touchlab.kampkit.android.MainApp">
+        <activity
+            android:name="co.touchlab.kampkit.android.MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -4,7 +4,7 @@ object Versions {
     val compile_sdk = 30
 
     val kotlin = "1.5.10"
-    val android_gradle_plugin = "4.1.1"
+    val android_gradle_plugin = "7.1.0-alpha02"
 
     val buildToolsVersion = "30.0.3"
     val coroutines = "1.5.0-native-mt"
@@ -21,15 +21,15 @@ object Versions {
     val stately = "1.1.7"
     val serialization = "1.2.1"
     val kotlinxDateTime = "0.2.1"
-    val turbine = "0.5.1"
+    val turbine = "0.5.2"
 
     object AndroidX {
-        val appcompat = "1.3.0"
-        val constraintlayout = "2.0.4"
-        val core = "1.5.0"
+        val appcompat = "1.4.0-alpha02"
+        val constraintlayout = "2.1.0-beta02"
+        val core = "1.6.0-rc01"
         val lifecycle = "2.3.1"
-        val recyclerview = "1.2.0"
-        val swipeRefresh = "1.1.0"
+        val recyclerview = "1.2.1"
+        val swipeRefresh = "1.2.0-alpha01"
         val test = "1.3.0"
         val test_ext = "1.1.2"
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-all.zip

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,2 @@
 include(":app", ":shared")
 rootProject.name = "KaMPKit"
-enableFeaturePreview("GRADLE_METADATA")

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -10,22 +10,31 @@ plugins {
 }
 
 android {
-    compileSdkVersion(Versions.compile_sdk)
+    compileSdk = Versions.compile_sdk
     defaultConfig {
-        minSdkVersion(Versions.min_sdk)
-        targetSdkVersion(Versions.target_sdk)
-        versionCode = 1
-        versionName = "1.0"
+        minSdk = Versions.min_sdk
+        targetSdk = Versions.target_sdk
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    lintOptions {
+    lint {
         isWarningsAsErrors = true
         isAbortOnError = true
     }
 }
 
 version = "1.0"
+
+android {
+    configurations {
+        create("androidTestApi")
+        create("androidTestDebugApi")
+        create("androidTestReleaseApi")
+        create("testApi")
+        create("testDebugApi")
+        create("testReleaseApi")
+    }
+}
 
 kotlin {
     android()


### PR DESCRIPTION
## Description]
Preparing for introducing Compose, which requires Android Studio Canary,
which requires Gradle 7+

## Solution
- Upgrade Gradle and Android Gradle Plugin
- Make necessary changes to accomodate the new Gradle and AGP APIs

## Testing
- `./gradlew build`
- manual testing of Android and iOS apps
