### PR TITLE
Refactor DataState.Loading

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,7 +40,7 @@ android {
 
     kotlinOptions {
         jvmTarget = "1.8"
-        freeCompilerArgs = listOf("-Xopt-in=kotlin.RequiresOptIn")
+        freeCompilerArgs += listOf("-Xopt-in=kotlin.RequiresOptIn")
     }
 
     composeOptions {

--- a/app/src/main/java/co/touchlab/kampkit/android/BreedViewModel.kt
+++ b/app/src/main/java/co/touchlab/kampkit/android/BreedViewModel.kt
@@ -24,7 +24,7 @@ class BreedViewModel : ViewModel(), KoinComponent {
     private val scope = viewModelScope
     private val breedModel: BreedModel = BreedModel()
     private val _breedStateFlow: MutableStateFlow<DataState<ItemDataSummary>> = MutableStateFlow(
-        DataState.Loading
+        DataState.Loading<ItemDataSummary>()
     )
 
     val breedStateFlow: StateFlow<DataState<ItemDataSummary>> = _breedStateFlow
@@ -41,7 +41,12 @@ class BreedViewModel : ViewModel(), KoinComponent {
                 breedModel.refreshBreedsIfStale(true),
                 breedModel.getBreedsFromCache()
             ).flattenMerge().collect { dataState ->
-                _breedStateFlow.value = dataState
+                if (dataState is DataState.Loading) {
+                    val newLoadingState = DataState.Loading(_breedStateFlow.value)
+                    _breedStateFlow.value = newLoadingState
+                } else {
+                    _breedStateFlow.value = dataState
+                }
             }
         }
     }
@@ -49,8 +54,13 @@ class BreedViewModel : ViewModel(), KoinComponent {
     fun refreshBreeds(forced: Boolean = false) {
         scope.launch {
             log.v { "refreshBreeds" }
-            breedModel.refreshBreedsIfStale(forced).collect {
-                _breedStateFlow.value = it
+            breedModel.refreshBreedsIfStale(forced).collect { dataState ->
+                if (dataState is DataState.Loading) {
+                    val newLoadingState = DataState.Loading(_breedStateFlow.value)
+                    _breedStateFlow.value = newLoadingState
+                } else {
+                    _breedStateFlow.value = dataState
+                }
             }
         }
     }

--- a/app/src/main/java/co/touchlab/kampkit/android/BreedViewModel.kt
+++ b/app/src/main/java/co/touchlab/kampkit/android/BreedViewModel.kt
@@ -24,7 +24,7 @@ class BreedViewModel : ViewModel(), KoinComponent {
     private val scope = viewModelScope
     private val breedModel: BreedModel = BreedModel()
     private val _breedStateFlow: MutableStateFlow<DataState<ItemDataSummary>> = MutableStateFlow(
-        DataState.Loading<ItemDataSummary>()
+        DataState.Loading()
     )
 
     val breedStateFlow: StateFlow<DataState<ItemDataSummary>> = _breedStateFlow

--- a/app/src/main/java/co/touchlab/kampkit/android/ui/Composables.kt
+++ b/app/src/main/java/co/touchlab/kampkit/android/ui/Composables.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import co.touchlab.kampkit.android.R
 import co.touchlab.kampkit.db.Breed
@@ -62,12 +63,18 @@ fun FavoriteIcon(breed: Breed) {
         if (fav) {
             Image(
                 painter = painterResource(id = R.drawable.ic_favorite_border_24px),
-                contentDescription = "Favorite $breed"
+                contentDescription = stringResource(
+                    id = R.string.favorite_breed,
+                    formatArgs = arrayOf(breed.name)
+                )
             )
         } else {
             Image(
                 painter = painterResource(id = R.drawable.ic_favorite_24px),
-                contentDescription = "Unfavorite $breed"
+                contentDescription = stringResource(
+                    id = R.string.unfavorite_breed,
+                    formatArgs = arrayOf(breed.name)
+                )
             )
         }
     }
@@ -97,19 +104,21 @@ fun Loading(
 @Composable
 fun Empty() {
     Column(
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier
+            .fillMaxSize()
             .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Text("Sorry, no doggos found")
+        Text(stringResource(id = R.string.no_doggos))
     }
 }
 
 @Composable
 fun Error(errorState: DataState.Error) {
     Column(
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier
+            .fillMaxSize()
             .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/java/co/touchlab/kampkit/android/ui/Composables.kt
+++ b/app/src/main/java/co/touchlab/kampkit/android/ui/Composables.kt
@@ -17,9 +17,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -78,11 +75,11 @@ fun FavoriteIcon(breed: Breed) {
 
 @Composable
 fun Loading(
-    lastState: DataState<ItemDataSummary>,
+    lastState: DataState<ItemDataSummary>?,
     favoriteBreed: (Breed) -> Unit
 ) {
     when (lastState) {
-        DataState.Loading -> {
+        is DataState.Loading -> {
             // Nothing here, because it's taken care of by SwipeRefresh
         }
         DataState.Empty -> {
@@ -134,21 +131,17 @@ fun MainScreen(
     dataState: DataState<ItemDataSummary>,
     favoriteBreed: (Breed) -> Unit
 ) {
-    val lastState: MutableState<DataState<ItemDataSummary>> = remember { mutableStateOf(dataState) }
     when (dataState) {
-        DataState.Loading -> {
-            Loading(lastState = lastState.value, favoriteBreed = favoriteBreed)
+        is DataState.Loading -> {
+            Loading(dataState.lastDataState, favoriteBreed = favoriteBreed)
         }
         DataState.Empty -> {
-            lastState.value = dataState
             Empty()
         }
         is DataState.Error -> {
-            lastState.value = dataState
             Error(errorState = dataState)
         }
         is DataState.Success<ItemDataSummary> -> {
-            lastState.value = dataState
             Success(successState = dataState, favoriteBreed)
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,7 @@
 <resources>
     <string name="app_name">KaMP Kit</string>
+    <string name="no_doggos">Sorry, no doggos found</string>
+    <string name="favorite_breed">favorite %1$s</string>
+    <string name="unfavorite_breed">unfavorite %1$s</string>
+
 </resources>

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -11,7 +11,7 @@ object Versions {
     val kermit = "0.1.9"
     val koin = "3.0.2"
     val ktlint_gradle_plugin = "10.0.0"
-    val ktor = "1.6.0"
+    val ktor = "1.6.1"
     val junit = "4.13.2"
     val material = "1.3.0"
     val desugarJdkLibs = "1.1.5"

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -32,9 +32,9 @@ object Versions {
     }
 
     object Compose {
-        const val compose = "1.0.0-rc01"
-        const val activity = "1.3.0-rc01"
-        const val accompanist = "0.13.0"
+        const val compose = "1.0.0-rc02"
+        const val activity = "1.3.0-rc02"
+        const val accompanist = "0.14.0"
     }
 }
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -4,7 +4,7 @@ object Versions {
     val compile_sdk = 30
 
     val kotlin = "1.5.10"
-    val android_gradle_plugin = "7.1.0-alpha02"
+    val android_gradle_plugin = "7.1.0-alpha03"
 
     val buildToolsVersion = "30.0.3"
     val coroutines = "1.5.0-native-mt"

--- a/ios/KaMPKitiOS/BreedCell.swift
+++ b/ios/KaMPKitiOS/BreedCell.swift
@@ -9,7 +9,7 @@
 import UIKit
 import shared
 
-protocol BreedCellDelegate: class {
+protocol BreedCellDelegate: AnyObject {
     func toggleFavorite(_ breed: Breed)
 }
 

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/ktor/DogApiImpl.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/ktor/DogApiImpl.kt
@@ -4,6 +4,7 @@ import co.touchlab.kampkit.response.BreedResult
 import co.touchlab.kermit.Kermit
 import co.touchlab.stately.ensureNeverFrozen
 import io.ktor.client.HttpClient
+import io.ktor.client.features.HttpTimeout
 import io.ktor.client.features.json.JsonFeature
 import io.ktor.client.features.json.serializer.KotlinxSerializer
 import io.ktor.client.features.logging.LogLevel
@@ -32,6 +33,12 @@ class DogApiImpl(log: Kermit) : KtorApi {
             }
 
             level = LogLevel.INFO
+        }
+        install(HttpTimeout) {
+            val timeout = 3000L
+            requestTimeoutMillis = timeout
+            connectTimeoutMillis = timeout
+            socketTimeoutMillis = timeout
         }
     }
 

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/BreedModel.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/BreedModel.kt
@@ -30,7 +30,7 @@ class BreedModel : KoinComponent {
     }
 
     fun refreshBreedsIfStale(forced: Boolean = false): Flow<DataState<ItemDataSummary>> = flow {
-        emit(DataState.Loading)
+        emit(DataState.Loading())
         val currentTimeMS = clock.now().toEpochMilliseconds()
         val stale = isBreedListStale(currentTimeMS)
         val networkBreedDataState: DataState<ItemDataSummary>
@@ -48,7 +48,7 @@ class BreedModel : KoinComponent {
                     // Pass the error along
                     emit(networkBreedDataState)
                 }
-                DataState.Loading -> {
+                is DataState.Loading -> {
                     // Won't ever happen
                 }
             }

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/DataState.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/DataState.kt
@@ -4,5 +4,5 @@ sealed class DataState<out T> {
     data class Success<T>(val data: T) : DataState<T>()
     data class Error(val exception: String) : DataState<Nothing>()
     object Empty : DataState<Nothing>()
-    object Loading : DataState<Nothing>()
+    data class Loading<T>(val lastDataState: DataState<T>? = null) : DataState<T>()
 }

--- a/shared/src/commonTest/kotlin/co/touchlab/kampkit/BreedModelTest.kt
+++ b/shared/src/commonTest/kotlin/co/touchlab/kampkit/BreedModelTest.kt
@@ -79,7 +79,7 @@ class BreedModelTest : BaseTest() {
         flowOf(model.refreshBreedsIfStale(), model.getBreedsFromCache())
             .flattenMerge().test {
                 // Loading
-                assertEquals(DataState.Loading, expectItem())
+                assertEquals(DataState.Loading(), expectItem())
                 // No Favorites
                 assertEquals(dataStateSuccessNoFavorite, expectItem())
                 // Add 1 favorite breed
@@ -98,7 +98,7 @@ class BreedModelTest : BaseTest() {
             flowOf(model.refreshBreedsIfStale(), model.getBreedsFromCache())
                 .flattenMerge().test {
                     // Loading
-                    assertEquals(DataState.Loading, expectItem())
+                    assertEquals(DataState.Loading(), expectItem())
                     assertEquals(dataStateSuccessNoFavorite, expectItem())
                     // "Like" the Australian breed
                     model.updateBreedFavorite(australianNoLike)
@@ -114,7 +114,7 @@ class BreedModelTest : BaseTest() {
             flowOf(model.refreshBreedsIfStale(true), model.getBreedsFromCache())
                 .flattenMerge().test {
                     // Loading
-                    assertEquals(DataState.Loading, expectItem())
+                    assertEquals(DataState.Loading(), expectItem())
                     // Get the new result with the Australian breed liked
                     assertEquals(dataStateSuccessFavorite, expectItem())
                     cancel()
@@ -129,7 +129,7 @@ class BreedModelTest : BaseTest() {
         ktorApi.prepareResult(successResult)
         flowOf(model.refreshBreedsIfStale(), model.getBreedsFromCache()).flattenMerge()
             .test(timeout = Duration.seconds(30)) {
-                assertEquals(DataState.Loading, expectItem())
+                assertEquals(DataState.Loading(), expectItem())
                 val oldBreeds = expectItem()
                 assertTrue(oldBreeds is DataState.Success)
                 assertEquals(
@@ -145,7 +145,7 @@ class BreedModelTest : BaseTest() {
         ktorApi.prepareResult(resultWithExtraBreed)
         flowOf(model.refreshBreedsIfStale(), model.getBreedsFromCache()).flattenMerge()
             .test(timeout = Duration.seconds(30)) {
-                assertEquals(DataState.Loading, expectItem())
+                assertEquals(DataState.Loading(), expectItem())
                 val updated = expectItem()
                 assertTrue(updated is DataState.Success)
                 assertEquals(resultWithExtraBreed.message.keys.size, updated.data.allItems.size)


### PR DESCRIPTION
## Summary
Loading state should display both the loading indicator, and whatever UI is already showing. This means remembering the last non-Loading state. Got around this issue by using `remember { }` in `Composable`s, but this issue will come up again in Swift UI, as all UI are emitted as distinct, whereas the Loading UI is a combination of the Loading indicator and the current UI state. We got away with this fine with the Android View system and UI Kit, as they implicitly held state. But we can no longer, and should no longer, rely on Views to hold state.
    
## Fix
Make `DataState.Loading` hold on to the last non-Loading state emitted, so they can both be displayed at the same time. This could also be solved via a `SharedFlow` with a cache of 2. However, I didn't want to worry about translating that cache to Combine or RxSwift if we adopt that later on. Adding a single parameter to Loading seemed like the simplest solution.
    
- dependency update: **updated AGP to 7.1.0-alpha03** to keep current with Android Studio Bumblebee 2021.1.1 Canary 3
    
## Testing
- `./gradlew :app:build`
- `./gradlew :shared:build`
- `xcodebuild -workspace ios/KaMPKitiOS.xcworkspace -scheme KaMPKitiOS
    -sdk iphoneos -configuration Debug build -destination name="iPhone 8"`
- manual testing of clicking and swipe-to-refresh on iOS and Android

