### PR TITLE
[Issue-0000] Alternative Loading state refactor

### DIFF
--- a/app/src/main/java/co/touchlab/kampkit/android/BreedViewModel.kt
+++ b/app/src/main/java/co/touchlab/kampkit/android/BreedViewModel.kt
@@ -4,8 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kampkit.db.Breed
 import co.touchlab.kampkit.models.BreedModel
-import co.touchlab.kampkit.models.DataState
 import co.touchlab.kampkit.models.ItemDataSummary
+import co.touchlab.kampkit.models.DataState
 import co.touchlab.kermit.Kermit
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -24,7 +24,7 @@ class BreedViewModel : ViewModel(), KoinComponent {
     private val scope = viewModelScope
     private val breedModel: BreedModel = BreedModel()
     private val _breedStateFlow: MutableStateFlow<DataState<ItemDataSummary>> = MutableStateFlow(
-        DataState.Loading
+        DataState(loading = true)
     )
 
     val breedStateFlow: StateFlow<DataState<ItemDataSummary>> = _breedStateFlow
@@ -41,7 +41,12 @@ class BreedViewModel : ViewModel(), KoinComponent {
                 breedModel.refreshBreedsIfStale(true),
                 breedModel.getBreedsFromCache()
             ).flattenMerge().collect { dataState ->
-                _breedStateFlow.value = dataState
+                if (dataState.loading) {
+                    val temp = _breedStateFlow.value.copy(loading = true)
+                    _breedStateFlow.value = temp
+                } else {
+                    _breedStateFlow.value = dataState
+                }
             }
         }
     }
@@ -49,8 +54,13 @@ class BreedViewModel : ViewModel(), KoinComponent {
     fun refreshBreeds(forced: Boolean = false) {
         scope.launch {
             log.v { "refreshBreeds" }
-            breedModel.refreshBreedsIfStale(forced).collect {
-                _breedStateFlow.value = it
+            breedModel.refreshBreedsIfStale(forced).collect { dataState ->
+                if (dataState.loading) {
+                    val temp = _breedStateFlow.value.copy(loading = true)
+                    _breedStateFlow.value = temp
+                } else {
+                    _breedStateFlow.value = dataState
+                }
             }
         }
     }

--- a/app/src/main/java/co/touchlab/kampkit/android/BreedViewModel.kt
+++ b/app/src/main/java/co/touchlab/kampkit/android/BreedViewModel.kt
@@ -4,8 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kampkit.db.Breed
 import co.touchlab.kampkit.models.BreedModel
-import co.touchlab.kampkit.models.ItemDataSummary
 import co.touchlab.kampkit.models.DataState
+import co.touchlab.kampkit.models.ItemDataSummary
 import co.touchlab.kermit.Kermit
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/main/java/co/touchlab/kampkit/android/MainActivity.kt
+++ b/app/src/main/java/co/touchlab/kampkit/android/MainActivity.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import co.touchlab.kampkit.android.ui.MainScreen
 import co.touchlab.kampkit.android.ui.theme.KaMPKitTheme
-import co.touchlab.kampkit.models.DataState
 import co.touchlab.kermit.Kermit
 import com.google.accompanist.swiperefresh.SwipeRefresh
 import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
@@ -33,7 +32,7 @@ class MainActivity : AppCompatActivity(), KoinComponent {
                     val dogsState by viewModel.breedStateFlow.collectAsState()
                     val isRefreshingState by remember(dogsState) {
                         derivedStateOf {
-                            dogsState is DataState.Loading
+                            dogsState.loading
                         }
                     }
 
@@ -48,7 +47,8 @@ class MainActivity : AppCompatActivity(), KoinComponent {
                 }
             }
         }
-
-        viewModel.refreshBreeds()
+        if (viewModel.breedStateFlow.value.data == null) {
+            viewModel.refreshBreeds()
+        }
     }
 }

--- a/app/src/main/java/co/touchlab/kampkit/android/ui/Composables.kt
+++ b/app/src/main/java/co/touchlab/kampkit/android/ui/Composables.kt
@@ -17,17 +17,14 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import co.touchlab.kampkit.android.R
 import co.touchlab.kampkit.db.Breed
-import co.touchlab.kampkit.models.DataState
 import co.touchlab.kampkit.models.ItemDataSummary
+import co.touchlab.kampkit.models.DataState
 
 @Composable
 fun DogList(breeds: List<Breed>, onItemClick: (Breed) -> Unit) {
@@ -77,30 +74,10 @@ fun FavoriteIcon(breed: Breed) {
 }
 
 @Composable
-fun Loading(
-    lastState: DataState<ItemDataSummary>,
-    favoriteBreed: (Breed) -> Unit
-) {
-    when (lastState) {
-        DataState.Loading -> {
-            // Nothing here, because it's taken care of by SwipeRefresh
-        }
-        DataState.Empty -> {
-            Empty()
-        }
-        is DataState.Error -> {
-            Error(errorState = lastState)
-        }
-        is DataState.Success -> {
-            Success(lastState, favoriteBreed)
-        }
-    }
-}
-
-@Composable
 fun Empty() {
     Column(
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier
+            .fillMaxSize()
             .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -110,23 +87,24 @@ fun Empty() {
 }
 
 @Composable
-fun Error(errorState: DataState.Error) {
+fun Error(error: String) {
     Column(
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier
+            .fillMaxSize()
             .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Text(text = errorState.exception)
+        Text(text = error)
     }
 }
 
 @Composable
 fun Success(
-    successState: DataState.Success<ItemDataSummary>,
+    successData: ItemDataSummary,
     favoriteBreed: (Breed) -> Unit
 ) {
-    DogList(breeds = successState.data.allItems, favoriteBreed)
+    DogList(breeds = successData.allItems, favoriteBreed)
 }
 
 @Composable
@@ -134,22 +112,15 @@ fun MainScreen(
     dataState: DataState<ItemDataSummary>,
     favoriteBreed: (Breed) -> Unit
 ) {
-    val lastState: MutableState<DataState<ItemDataSummary>> = remember { mutableStateOf(dataState) }
-    when (dataState) {
-        DataState.Loading -> {
-            Loading(lastState = lastState.value, favoriteBreed = favoriteBreed)
-        }
-        DataState.Empty -> {
-            lastState.value = dataState
-            Empty()
-        }
-        is DataState.Error -> {
-            lastState.value = dataState
-            Error(errorState = dataState)
-        }
-        is DataState.Success<ItemDataSummary> -> {
-            lastState.value = dataState
-            Success(successState = dataState, favoriteBreed)
-        }
+    if (dataState.empty) {
+        Empty()
+    }
+    val data = dataState.data
+    if (data != null) {
+        Success(successData = data, favoriteBreed)
+    }
+    val exception = dataState.exception
+    if (exception != null) {
+        Error(exception)
     }
 }

--- a/app/src/main/java/co/touchlab/kampkit/android/ui/Composables.kt
+++ b/app/src/main/java/co/touchlab/kampkit/android/ui/Composables.kt
@@ -23,8 +23,8 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import co.touchlab.kampkit.android.R
 import co.touchlab.kampkit.db.Breed
-import co.touchlab.kampkit.models.ItemDataSummary
 import co.touchlab.kampkit.models.DataState
+import co.touchlab.kampkit.models.ItemDataSummary
 
 @Composable
 fun DogList(breeds: List<Breed>, onItemClick: (Breed) -> Unit) {

--- a/ios/KaMPKitiOS/ViewController.swift
+++ b/ios/KaMPKitiOS/ViewController.swift
@@ -18,22 +18,21 @@ class BreedsViewController: UIViewController {
     private let refreshControl = UIRefreshControl()
 
     lazy var adapter: NativeViewModel = NativeViewModel(
-        onLoading: { /* Loading spinner is shown automatically on iOS */
-            [weak self] in
-            guard let self = self else { return }
-            if (!(self.refreshControl.isRefreshing)) {
-                self.refreshControl.beginRefreshing()
+        onDataState: {
+            [weak self] dataState in
+            
+            if (dataState.loading) {
+                self?.refreshControl.beginRefreshing()
+            } else {
+                self?.refreshControl.endRefreshing()
             }
-        },
-        onSuccess: {
-            [weak self] summary in self?.viewUpdateSuccess(for: summary)
-            self?.refreshControl.endRefreshing()
-        },
-        onError: { [weak self] error in self?.errorUpdate(for: error)
-            self?.refreshControl.endRefreshing()
-        },
-        onEmpty: { /* Show "No doggos found!" message */
-            [weak self] in self?.refreshControl.endRefreshing()
+            if let exception = dataState.exception {
+                self?.errorUpdate(for: exception)
+                self?.adapter.consumeError()
+            }
+            if let data = dataState.data {
+                self?.viewUpdateSuccess(for: data)
+            }
         }
     )
     

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/ktor/DogApiImpl.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/ktor/DogApiImpl.kt
@@ -4,6 +4,7 @@ import co.touchlab.kampkit.response.BreedResult
 import co.touchlab.kermit.Kermit
 import co.touchlab.stately.ensureNeverFrozen
 import io.ktor.client.HttpClient
+import io.ktor.client.features.HttpTimeout
 import io.ktor.client.features.json.JsonFeature
 import io.ktor.client.features.json.serializer.KotlinxSerializer
 import io.ktor.client.features.logging.LogLevel
@@ -32,6 +33,12 @@ class DogApiImpl(log: Kermit) : KtorApi {
             }
 
             level = LogLevel.INFO
+        }
+        install(HttpTimeout) {
+            val timeout = 3000L
+            connectTimeoutMillis = timeout
+            requestTimeoutMillis = timeout
+            socketTimeoutMillis = timeout
         }
     }
 

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/BreedModel.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/BreedModel.kt
@@ -30,27 +30,16 @@ class BreedModel : KoinComponent {
     }
 
     fun refreshBreedsIfStale(forced: Boolean = false): Flow<DataState<ItemDataSummary>> = flow {
-        emit(DataState.Loading)
+        emit(DataState(loading = true))
         val currentTimeMS = clock.now().toEpochMilliseconds()
         val stale = isBreedListStale(currentTimeMS)
         val networkBreedDataState: DataState<ItemDataSummary>
         if (stale || forced) {
             networkBreedDataState = getBreedsFromNetwork(currentTimeMS)
-            when (networkBreedDataState) {
-                DataState.Empty -> {
-                    // Pass the empty response along
-                    emit(networkBreedDataState)
-                }
-                is DataState.Success -> {
-                    dbHelper.insertBreeds(networkBreedDataState.data.allItems)
-                }
-                is DataState.Error -> {
-                    // Pass the error along
-                    emit(networkBreedDataState)
-                }
-                DataState.Loading -> {
-                    // Won't ever happen
-                }
+            if (networkBreedDataState.data != null) {
+                dbHelper.insertBreeds(networkBreedDataState.data.allItems)
+            } else {
+                emit(networkBreedDataState)
             }
         }
     }
@@ -61,8 +50,8 @@ class BreedModel : KoinComponent {
                 if (itemList.isEmpty()) {
                     null
                 } else {
-                    DataState.Success(
-                        ItemDataSummary(
+                    DataState<ItemDataSummary>(
+                        data = ItemDataSummary(
                             itemList.maxByOrNull { it.name.length },
                             itemList
                         )
@@ -88,9 +77,9 @@ class BreedModel : KoinComponent {
             log.v { "Fetched ${breedList.size} breeds from network" }
             settings.putLong(DB_TIMESTAMP_KEY, currentTimeMS)
             if (breedList.isEmpty()) {
-                DataState.Empty
+                DataState<ItemDataSummary>(empty = true)
             } else {
-                DataState.Success(
+                DataState<ItemDataSummary>(
                     ItemDataSummary(
                         null,
                         breedList.map { Breed(0L, it, 0L) }
@@ -99,7 +88,7 @@ class BreedModel : KoinComponent {
             }
         } catch (e: Exception) {
             log.e(e) { "Error downloading breed list" }
-            DataState.Error("Unable to download breed list")
+            DataState<ItemDataSummary>(exception = "Unable to download breed list")
         }
     }
 

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/DataState.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/DataState.kt
@@ -1,8 +1,8 @@
 package co.touchlab.kampkit.models
 
-sealed class DataState<out T> {
-    data class Success<T>(val data: T) : DataState<T>()
-    data class Error(val exception: String) : DataState<Nothing>()
-    object Empty : DataState<Nothing>()
-    object Loading : DataState<Nothing>()
-}
+data class DataState<out T>(
+    val data: T? = null,
+    val exception: String? = null,
+    val empty: Boolean = false,
+    val loading: Boolean = false
+)

--- a/shared/src/commonTest/kotlin/co/touchlab/kampkit/BreedModelTest.kt
+++ b/shared/src/commonTest/kotlin/co/touchlab/kampkit/BreedModelTest.kt
@@ -42,11 +42,11 @@ class BreedModelTest : BaseTest() {
         private val appenzeller = Breed(1, "appenzeller", 0L)
         private val australianNoLike = Breed(2, "australian", 0L)
         private val australianLike = Breed(2, "australian", 1L)
-        val dataStateSuccessNoFavorite = DataState.Success(
-            ItemDataSummary(appenzeller, listOf(appenzeller, australianNoLike))
+        val dataStateSuccessNoFavorite = DataState(
+            data = ItemDataSummary(appenzeller, listOf(appenzeller, australianNoLike))
         )
-        private val dataStateSuccessFavorite = DataState.Success(
-            ItemDataSummary(appenzeller, listOf(appenzeller, australianLike))
+        private val dataStateSuccessFavorite = DataState(
+            data = ItemDataSummary(appenzeller, listOf(appenzeller, australianLike))
         )
     }
 
@@ -61,7 +61,7 @@ class BreedModelTest : BaseTest() {
         settings.putLong(BreedModel.DB_TIMESTAMP_KEY, currentTimeMS)
         assertTrue(ktorApi.calledCount == 0)
 
-        val expectedError = DataState.Error("Unable to download breed list")
+        val expectedError = DataState<ItemDataSummary>(exception = "Unable to download breed list")
         val actualError = model.getBreedsFromNetwork(0L)
 
         assertEquals(
@@ -79,7 +79,7 @@ class BreedModelTest : BaseTest() {
         flowOf(model.refreshBreedsIfStale(), model.getBreedsFromCache())
             .flattenMerge().test {
                 // Loading
-                assertEquals(DataState.Loading, expectItem())
+                assertEquals(DataState(loading = true), expectItem())
                 // No Favorites
                 assertEquals(dataStateSuccessNoFavorite, expectItem())
                 // Add 1 favorite breed
@@ -98,7 +98,7 @@ class BreedModelTest : BaseTest() {
             flowOf(model.refreshBreedsIfStale(), model.getBreedsFromCache())
                 .flattenMerge().test {
                     // Loading
-                    assertEquals(DataState.Loading, expectItem())
+                    assertEquals(DataState(loading = true), expectItem())
                     assertEquals(dataStateSuccessNoFavorite, expectItem())
                     // "Like" the Australian breed
                     model.updateBreedFavorite(australianNoLike)
@@ -114,7 +114,7 @@ class BreedModelTest : BaseTest() {
             flowOf(model.refreshBreedsIfStale(true), model.getBreedsFromCache())
                 .flattenMerge().test {
                     // Loading
-                    assertEquals(DataState.Loading, expectItem())
+                    assertEquals(DataState(loading = true), expectItem())
                     // Get the new result with the Australian breed liked
                     assertEquals(dataStateSuccessFavorite, expectItem())
                     cancel()
@@ -129,12 +129,13 @@ class BreedModelTest : BaseTest() {
         ktorApi.prepareResult(successResult)
         flowOf(model.refreshBreedsIfStale(), model.getBreedsFromCache()).flattenMerge()
             .test(timeout = Duration.seconds(30)) {
-                assertEquals(DataState.Loading, expectItem())
+                assertEquals(DataState(loading = true), expectItem())
                 val oldBreeds = expectItem()
-                assertTrue(oldBreeds is DataState.Success)
+                val data = oldBreeds.data
+                assertTrue(data != null)
                 assertEquals(
                     ktorApi.successResult().message.keys.size,
-                    oldBreeds.data.allItems.size
+                    data.allItems.size
                 )
             }
 
@@ -145,10 +146,11 @@ class BreedModelTest : BaseTest() {
         ktorApi.prepareResult(resultWithExtraBreed)
         flowOf(model.refreshBreedsIfStale(), model.getBreedsFromCache()).flattenMerge()
             .test(timeout = Duration.seconds(30)) {
-                assertEquals(DataState.Loading, expectItem())
+                assertEquals(DataState(loading = true), expectItem())
                 val updated = expectItem()
-                assertTrue(updated is DataState.Success)
-                assertEquals(resultWithExtraBreed.message.keys.size, updated.data.allItems.size)
+                val data = updated.data
+                assertTrue(data != null)
+                assertEquals(resultWithExtraBreed.message.keys.size, data.allItems.size)
             }
     }
 


### PR DESCRIPTION
## Summary
The Loading UI is usually shown in conjunction with other UI, such as an error view, or valid data. Consuming it with a when statement and treating it like any other state may not make sense with Compose and Swift UI. I tried a different approach here, giving the Loading state the last valid `DataState` as well: https://github.com/touchlab-lab/KaMPKit/pull/6

## Fix
In this PR, I'm using the classic NetworkBoundResource approach, where the DataState is not a `sealed class`; instead, it contains nullable versions of all possible states.

## Testing
<!-- Remove any lines that were not performed -->
- `./gradlew :app:build`
- `./gradlew :shared:build`
- `xcodebuild -workspace ios/KaMPKitiOS.xcworkspace -scheme KaMPKitiOS -sdk iphoneos -configuration Debug build -destination name="iPhone 8"`
- manual testing